### PR TITLE
Updated License in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,6 @@ Claudia Luque Fernández @claucookie
 
 License
 -------
-http://opensource.org/licenses/MIT
+GNU General Public License version 2
+https://opensource.org/licenses/GPL-2.0
 


### PR DESCRIPTION
There was a license mismatch. repository license is GPL-2.0, and in readme it's MIT. Changed the readme to GPL-2.0.